### PR TITLE
use powershell winget rather than ./winget.exe

### DIFF
--- a/Powershell Scripts/Winget/remediate-install-apps-from-url.ps1
+++ b/Powershell Scripts/Winget/remediate-install-apps-from-url.ps1
@@ -87,7 +87,7 @@ $apps = get-content $templateFilePath | select-object -skip 1
 foreach ($app in $apps) {
 
 write-host "Installing $app"
-.\winget.exe install --exact --id $app --silent --accept-package-agreements --accept-source-agreements
+winget install --exact --id $app --silent --accept-package-agreements --accept-source-agreements
 }
 
 ##Delete the .old file to replace it with the new one


### PR DESCRIPTION
Using ./winget.exe threw an error on my clean windows 11 build - but you can just call winget from powershell so I did that and it worked.  I assume you can clear up the code that finds the Winget Path but I don't want to mess with that in case you need it elsewhere.