### PR TITLE
Fix MSI Handling in UninstallAppFull

### DIFF
--- a/De-Bloat/RemoveBloat.ps1
+++ b/De-Bloat/RemoveBloat.ps1
@@ -1487,8 +1487,6 @@ function UninstallAppFull {
     $allInstalledApps = $installedApps + $userInstalledApps | Where-Object { $_.DisplayName -eq "$appName" }
 
     # Loop through the list of installed applications and uninstall them
-
-    # Loop through the list of installed applications and uninstall them
     foreach ($app in $allInstalledApps) {
 
         $uninstallString = $app.UninstallString


### PR DESCRIPTION
Updates the UninstallAppFull function to better handle MSI uninstalls. Previously, it would fail out with "The file specified cannot be found." After updating the handling to utilize the "-argumentlist" flag, the uninstalls perform correctly.

<img width="922" height="171" alt="image" src="https://github.com/user-attachments/assets/3495d254-0e1d-4d48-8729-10fab11bde63" />
